### PR TITLE
Add Backspace ability to text input mode

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -143,14 +143,23 @@ func (ui *PneumaUI) Tick() {
 				ui.Redraw()
 			}
 		} else if ui.Mode == Input {
-			if ev.Key() == tcell.KeyEnter || ev.Key() == tcell.KeyEscape {
-				ui.Mode = Navigate
-			} else if ev.Key() == tcell.KeyRune {
-				ui.InputBuffer += string(ev.Rune())
+            switch ev.Key() {
+            case tcell.KeyEnter :
+                ui.Mode = Navigate
+            case tcell.KeyEscape:
+                ui.Mode = Navigate
+                ui.InputBuffer = ""
+            case tcell.KeyBackspace, tcell.KeyBackspace2:
+                ui.InputBuffer = ui.InputBuffer[:len(ui.InputBuffer) -1]
+                ui.Cursor.X--
+                ui.putRune(' ')
+            case tcell.KeyRune:
+                ui.InputBuffer += string(ev.Rune())
 				ui.putRune(ev.Rune())
 				ui.Cursor.X++
-			}
-		}
+            }
+
+        }
 	}
 }
 


### PR DESCRIPTION
This closes #8

The backspace key was not initially working. From the tcell docs, one
needs to cover both KeyBackspace and KeyBackspace2. The input mode now
uses KeyEnter to submit, KeyEscape to cancel and KeyBackspace to delete
characters. Input scrolling is not supported at this time.